### PR TITLE
Simplified return value

### DIFF
--- a/debug-js/get-started.js
+++ b/debug-js/get-started.js
@@ -19,11 +19,7 @@ function onClick() {
   updateLabel();
 }
 function inputsAreEmpty() {
-  if (getNumber1() === '' || getNumber2() === '') {
-    return true;
-  } else {
-    return false;
-  }
+  return getNumber1() === '' || getNumber2() === '';
 }
 function updateLabel() {
   var addend1 = getNumber1();


### PR DESCRIPTION
We can simplify the `inputsAreEmpty` function by using an `if` expression directly as the return value.